### PR TITLE
Update Pearson distance value in documentation

### DIFF
--- a/docs/Pearson.rst
+++ b/docs/Pearson.rst
@@ -71,7 +71,7 @@ Expected Output:
 .. code-block:: bash
 
 
-    >>>The Pearson distance between the two data points is: 0.010248
+    >>>The Pearson distance between the two data points is: 0.035074
 
 Academic Reference
 ------------------


### PR DESCRIPTION
The Pearson distance value example provided in the documentation is incorrect, and attempting to reproduce it with the provided code yields 0.035074 instead.